### PR TITLE
Header page numbers

### DIFF
--- a/lib/caracal/core/models/page_number_model.rb
+++ b/lib/caracal/core/models/page_number_model.rb
@@ -17,6 +17,7 @@ module Caracal
         # constants
         const_set(:DEFAULT_PAGE_NUMBER_ALIGN, :center)
         const_set(:DEFAULT_PAGE_NUMBER_SHOW,  false)
+        const_set(:DEFAULT_PAGE_NUMBER_LOCATION, :footer)
 
         # accessors
         attr_reader :page_number_align
@@ -24,6 +25,7 @@ module Caracal
         attr_reader :page_number_label_size
         attr_reader :page_number_number_size
         attr_reader :page_number_show
+        attr_reader :page_number_location
 
         # initialization
         def initialize(options={}, &block)
@@ -32,6 +34,7 @@ module Caracal
           @page_number_label_size   = nil
           @page_number_number_size  = nil
           @page_number_show         = DEFAULT_PAGE_NUMBER_SHOW
+          @page_number_location     = DEFAULT_PAGE_NUMBER_LOCATION
 
           super options, &block
         end
@@ -71,11 +74,15 @@ module Caracal
           @page_number_number_size = (v == 0) ? nil : v
         end
 
+        def location(value)
+          @page_number_location = value.to_s.to_sym
+        end
+
 
         #=============== VALIDATION ===========================
 
         def valid?
-          (!page_number_show || [:left, :center, :right].include?(page_number_align))
+          (!page_number_show || ([:left, :center, :right].include?(page_number_align) && [:footer, :header, :both].include?(page_number_location) ))
         end
 
 
@@ -85,7 +92,7 @@ module Caracal
         private
 
         def option_keys
-          [:align, :label, :label_size, :number_size, :show]
+          [:align, :label, :label_size, :number_size, :show, :location]
         end
 
       end

--- a/lib/caracal/core/models/relationship_model.rb
+++ b/lib/caracal/core/models/relationship_model.rb
@@ -18,6 +18,7 @@ module Caracal
         TYPE_MAP = {
           font:       'http://schemas.openxmlformats.org/officeDocument/2006/relationships/fontTable', 
           footer:     'http://schemas.openxmlformats.org/officeDocument/2006/relationships/footer',
+          header:     'http://schemas.openxmlformats.org/officeDocument/2006/relationships/header',
           image:      'http://schemas.openxmlformats.org/officeDocument/2006/relationships/image',
           link:       'http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink',
           numbering:  'http://schemas.openxmlformats.org/officeDocument/2006/relationships/numbering',

--- a/lib/caracal/core/page_numbers.rb
+++ b/lib/caracal/core/page_numbers.rb
@@ -25,6 +25,7 @@ module Caracal
           attr_reader :page_number_label_size
           attr_reader :page_number_number_size
           attr_reader :page_number_show
+          attr_reader :page_number_location
 
 
           #-------------------------------------------------------------
@@ -45,8 +46,9 @@ module Caracal
               @page_number_label_size   = model.page_number_label_size
               @page_number_number_size  = model.page_number_number_size
               @page_number_show         = model.page_number_show
+              @page_number_location     = model.page_number_location
             else
-              raise Caracal::Errors::InvalidModelError, 'page_numbers :align parameter must be :left, :center, or :right'
+              raise Caracal::Errors::InvalidModelError, 'page_numbers :align parameter must be :left, :center, or :right. :location parameter must be :footer, :header or :both'
             end
           end
 

--- a/lib/caracal/core/relationships.rb
+++ b/lib/caracal/core/relationships.rb
@@ -27,6 +27,7 @@ module Caracal
             [
               { target: 'fontTable.xml',  type: :font      },
               { target: 'footer1.xml',    type: :footer    },
+              { target: 'header1.xml',    type: :header    },
               { target: 'numbering.xml',  type: :numbering },
               { target: 'settings.xml',   type: :setting   },
               { target: 'styles.xml',     type: :style     }

--- a/lib/caracal/document.rb
+++ b/lib/caracal/document.rb
@@ -27,6 +27,7 @@ require 'caracal/renderers/custom_renderer'
 require 'caracal/renderers/document_renderer'
 require 'caracal/renderers/fonts_renderer'
 require 'caracal/renderers/footer_renderer'
+require 'caracal/renderers/header_renderer'
 require 'caracal/renderers/numbering_renderer'
 require 'caracal/renderers/package_relationships_renderer'
 require 'caracal/renderers/relationships_renderer'
@@ -144,6 +145,7 @@ module Caracal
         render_custom(zip)
         render_fonts(zip)
         render_footer(zip)
+        render_header(zip)
         render_settings(zip)
         render_styles(zip)
         render_document(zip)
@@ -216,6 +218,13 @@ module Caracal
       content = ::Caracal::Renderers::FooterRenderer.render(self)
 
       zip.put_next_entry('word/footer1.xml')
+      zip.write(content)
+    end
+
+    def render_header(zip)
+      content = ::Caracal::Renderers::HeaderRenderer.render(self)
+
+      zip.put_next_entry('word/header1.xml')
       zip.write(content)
     end
 

--- a/lib/caracal/renderers/content_types_renderer.rb
+++ b/lib/caracal/renderers/content_types_renderer.rb
@@ -28,6 +28,7 @@ module Caracal
             xml.send 'Override', { 'PartName' => '/docProps/custom.xml', 'ContentType' => 'application/vnd.openxmlformats-officedocument.custom-properties+xml' }
             xml.send 'Override', { 'PartName' => '/word/document.xml',   'ContentType' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml' }
             xml.send 'Override', { 'PartName' => '/word/footer1.xml',    'ContentType' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.footer+xml' }
+            xml.send 'Override', { 'PartName' => '/word/header1.xml',    'ContentType' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml' }
             xml.send 'Override', { 'PartName' => '/word/fontTable.xml',  'ContentType' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.fontTable+xml' }
             xml.send 'Override', { 'PartName' => '/word/numbering.xml',  'ContentType' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.numbering+xml' }
             xml.send 'Override', { 'PartName' => '/word/settings.xml',   'ContentType' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.settings+xml' }

--- a/lib/caracal/renderers/document_renderer.rb
+++ b/lib/caracal/renderers/document_renderer.rb
@@ -32,8 +32,15 @@ module Caracal
 
               xml['w'].sectPr do
                 if document.page_number_show
-                  if rel = document.find_relationship('footer1.xml')
-                    xml['w'].footerReference({ 'r:id' => rel.formatted_id, 'w:type' => 'default' })
+                  if [:header, :both].include? document.page_number_location
+                    if rel = document.find_relationship('header1.xml')
+                      xml['w'].headerReference({ 'r:id' => rel.formatted_id, 'w:type' => 'default' })
+                    end
+                  end
+                  if [:footer, :both].include? document.page_number_location
+                    if rel = document.find_relationship('footer1.xml')
+                      xml['w'].footerReference({ 'r:id' => rel.formatted_id, 'w:type' => 'default' })
+                    end
                   end
                 end
                 xml['w'].pgSz page_size_options

--- a/lib/caracal/renderers/header_renderer.rb
+++ b/lib/caracal/renderers/header_renderer.rb
@@ -1,0 +1,90 @@
+require 'nokogiri'
+
+require 'caracal/renderers/xml_renderer'
+
+
+module Caracal
+  module Renderers
+    class HeaderRenderer < XmlRenderer
+
+      #-------------------------------------------------------------
+      # Public Methods
+      #-------------------------------------------------------------
+
+      # This method produces the xml required for the `word/settings.xml`
+      # sub-document.
+      #
+      def to_xml
+        builder = ::Nokogiri::XML::Builder.with(declaration_xml) do |xml|
+          xml['w'].ftr root_options do
+            xml['w'].p paragraph_options do
+              xml['w'].pPr do
+                xml['w'].contextualSpacing({ 'w:val' => '0' })
+                xml['w'].jc({ 'w:val' => "#{ document.page_number_align }" })
+              end
+              unless document.page_number_label.nil?
+                xml['w'].r run_options do
+                  xml['w'].rPr do
+                    xml['w'].rStyle({ 'w:val' => 'PageNumber' })
+                    unless document.page_number_label_size.nil?
+                      xml['w'].sz({ 'w:val'  => document.page_number_label_size })
+                    end
+                  end
+                  xml['w'].t({ 'xml:space' => 'preserve' }) do
+                    xml.text "#{ document.page_number_label } "
+                  end
+                end
+              end
+              xml['w'].r run_options do
+                xml['w'].rPr do
+                  unless document.page_number_number_size.nil?
+                    xml['w'].sz({ 'w:val'  => document.page_number_number_size })
+                    xml['w'].szCs({ 'w:val' => document.page_number_number_size })
+                  end
+                end
+                xml['w'].fldChar({ 'w:fldCharType' => 'begin' })
+                xml['w'].instrText({ 'xml:space' => 'preserve' }) do
+                  xml.text 'PAGE'
+                end
+                xml['w'].fldChar({ 'w:fldCharType' => 'end' })
+              end
+              xml['w'].r run_options do
+                xml['w'].rPr do
+                  xml['w'].rtl({ 'w:val' => '0' })
+                end
+              end
+            end
+          end
+        end
+        builder.to_xml(save_options)
+      end
+
+
+      #-------------------------------------------------------------
+      # Private Methods
+      #-------------------------------------------------------------
+      private
+
+      def root_options
+        {
+          'xmlns:mc'  => 'http://schemas.openxmlformats.org/markup-compatibility/2006',
+          'xmlns:o'   => 'urn:schemas-microsoft-com:office:office',
+          'xmlns:r'   => 'http://schemas.openxmlformats.org/officeDocument/2006/relationships',
+          'xmlns:m'   => 'http://schemas.openxmlformats.org/officeDocument/2006/math',
+          'xmlns:v'   => 'urn:schemas-microsoft-com:vml',
+          'xmlns:wp'  => 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing',
+          'xmlns:w10' => 'urn:schemas-microsoft-com:office:word',
+          'xmlns:w'   => 'http://schemas.openxmlformats.org/wordprocessingml/2006/main',
+          'xmlns:wne' => 'http://schemas.microsoft.com/office/word/2006/wordml',
+          'xmlns:sl'  => 'http://schemas.openxmlformats.org/schemaLibrary/2006/main',
+          'xmlns:a'   => 'http://schemas.openxmlformats.org/drawingml/2006/main',
+          'xmlns:pic' => 'http://schemas.openxmlformats.org/drawingml/2006/picture',
+          'xmlns:c'   => 'http://schemas.openxmlformats.org/drawingml/2006/chart',
+          'xmlns:lc'  => 'http://schemas.openxmlformats.org/drawingml/2006/lockedCanvas',
+          'xmlns:dgm' => 'http://schemas.openxmlformats.org/drawingml/2006/diagram'
+        }
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Page numbers can be added to the header, footer or both with the `location` parameter in page_numbers:
```
docx.page_numbers true do
  align :right
  location :header | :footer | :both
end
```