### PR TITLE
Row properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -658,7 +658,36 @@ docx.table data, border_size: 4 do
 end
 ```
 
-Table cells can be styles using the `cell_style` method inside the table's block.  The method will attempt to apply any specified options against the collection of `TableModelCell` instances provided in the first argument.  Any improper options will fail silently.
+Table rows can be styled using the `row_style` method inside the table's block.  The method will attempt to apply any specified options against the collection of `TableModelRow` instances provided in the first argument.  Any improper options will fail silently.
+
+*As a convenience, the table provides the methods `table_rows` to facilitate building the first argument.*
+
+The example will style the first row to have fixed height, and all other rows to have a minimum height and avoid to break between pages (unless the row cannot fit in a single page).
+
+```ruby
+data = [
+  ['Header 1','Header 2'],
+  ['Cell 1', 'Cell 2'],
+  ['Cell 3', 'Cell 4'],
+  ['Cell 5', 'Cell 6'],
+  ['this should be in another page', ' some long text'*50]
+]
+docx.table data, border_size: 4 do
+  row_style table_rows.drop(1),
+            height: 2500,                  # height value of the row, in twips, maybe not used depending on height_calculation chosen
+            height_calculation: :at_least, # define how height will be calculated, default :auto
+            keep_together: true            # if true, will avoid breaking the row between pages, default false
+
+  row_style table_rows[0], height: 500, height_calculation: :exact
+end
+```
+height_calculation possible values are
+  * :auto, ignores height value, and calculate height based on cells content height
+  * :at_least, uses the biggest value between row height value and cells content height, acts like a minimum value for row height
+  * :exact, set the height to the exact value determined by row height, ignores cell content height, clipping cell content if bigger than row height
+
+
+Table cells can be styled using the `cell_style` method inside the table's block.  The method will attempt to apply any specified options against the collection of `TableModelCell` instances provided in the first argument.  Any improper options will fail silently.
 
 *As a convenience, the table provides the methods `rows`, `cols`, and `cells` to facilitate building the first argument.*
 

--- a/lib/caracal/core/models/table_model.rb
+++ b/lib/caracal/core/models/table_model.rb
@@ -1,28 +1,29 @@
 require 'caracal/core/models/base_model'
 require 'caracal/core/models/border_model'
+require 'caracal/core/models/table_row_model'
 require 'caracal/core/models/table_cell_model'
 
 
 module Caracal
   module Core
     module Models
-      
+
       # This class handles block options passed to the table
       # method.
       #
       class TableModel < BaseModel
-        
+
         #-------------------------------------------------------------
         # Configuration
         #-------------------------------------------------------------
-        
+
         # constants
         const_set(:DEFAULT_TABLE_ALIGN,             :center)    # weirdly, works better w/ full width
         const_set(:DEFAULT_TABLE_BORDER_COLOR,      'auto')
         const_set(:DEFAULT_TABLE_BORDER_LINE,       :single)
         const_set(:DEFAULT_TABLE_BORDER_SIZE,       0)          # units in 1/8 points
-        const_set(:DEFAULT_TABLE_BORDER_SPACING,    0)          
-        
+        const_set(:DEFAULT_TABLE_BORDER_SPACING,    0)
+
         # accessors
         attr_reader :table_align
         attr_reader :table_width
@@ -36,29 +37,29 @@ module Caracal
         attr_reader :table_border_right       # returns border model
         attr_reader :table_border_horizontal  # returns border model
         attr_reader :table_border_vertical    # returns border model
-        
+
         # initialization
         def initialize(options={}, &block)
-          @table_align          = DEFAULT_TABLE_ALIGN
-          @table_border_color   = DEFAULT_TABLE_BORDER_COLOR
-          @table_border_line    = DEFAULT_TABLE_BORDER_LINE
-          @table_border_size    = DEFAULT_TABLE_BORDER_SIZE
-          @table_border_spacing = DEFAULT_TABLE_BORDER_SPACING
-          
+          @table_align           = DEFAULT_TABLE_ALIGN
+          @table_border_color    = DEFAULT_TABLE_BORDER_COLOR
+          @table_border_line     = DEFAULT_TABLE_BORDER_LINE
+          @table_border_size     = DEFAULT_TABLE_BORDER_SIZE
+          @table_border_spacing  = DEFAULT_TABLE_BORDER_SPACING
+
           super options, &block
         end
-        
-        
+
+
         #-------------------------------------------------------------
         # Public Methods
         #-------------------------------------------------------------
-        
+
         #=============== DATA ACCESSORS =======================
-        
+
         def cells
           rows.flatten
         end
-        
+
         def cols
           rows.reduce([]) do |array, row|
             row.each_with_index do |cell, index|
@@ -68,24 +69,29 @@ module Caracal
             array
           end
         end
-        
+
         def rows
-          @table_data || [[]]
+          return [[]] unless @table_rows.first.is_a? Caracal::Core::Models::TableRowModel
+          @table_rows.map(&:cells)
         end
-        
-        
+
+        def table_rows
+          @table_rows
+        end
+
+
         #=============== STYLES ===============================
-        
+
         # This method sets explicit widths on all wrapped cells
         # that do not already have widths asided.
         #
         def calculate_width(container_width)
           width(container_width) unless table_width.to_i > 0
-          
+
           cells.each { |c| c.calculate_width(default_cell_width) }
         end
-        
-        # This method allows tables to be styled several cells 
+
+        # This method allows tables to be styled several cells
         # at a time.
         #
         # For example, this would style a header row.
@@ -97,12 +103,14 @@ module Caracal
         def cell_style(models, options={})
           [models].flatten.compact.each do |m|
             m.apply_styles(options)
-          end  
+          end
         end
-        
-        
+
+        alias_method :row_style, :cell_style
+
+
         #=============== GETTERS ==============================
-        
+
         # border attrs
         [:top, :bottom, :left, :right, :horizontal, :vertical].each do |m|
           [:color, :line, :size, :spacing].each do |attr|
@@ -116,17 +124,17 @@ module Caracal
             value = (model) ? model.total_size : table_border_size + (2 * table_border_spacing)
           end
         end
-        
-        
+
+
         #=============== SETTERS ==============================
-        
+
         # integers
         [:border_size, :border_spacing, :width].each do |m|
           define_method "#{ m }" do |value|
             instance_variable_set("@table_#{ m }", value.to_i)
           end
         end
-        
+
         # models
         [:top, :bottom, :left, :right, :horizontal, :vertical].each do |m|
           define_method "border_#{ m }" do |options = {}, &block|
@@ -134,63 +142,52 @@ module Caracal
             instance_variable_set("@table_border_#{ m }", Caracal::Core::Models::BorderModel.new(options, &block))
           end
         end
-        
+
         # strings
         [:border_color].each do |m|
           define_method "#{ m }" do |value|
             instance_variable_set("@table_#{ m }", value.to_s)
           end
         end
-        
+
         # symbols
         [:border_line, :align].each do |m|
           define_method "#{ m }" do |value|
             instance_variable_set("@table_#{ m }", value.to_s.to_sym)
           end
         end
-        
+
         # .data
         def data(value)
           begin
-            @table_data = value.map do |data_row|
-              data_row.map do |data_cell|
-                case data_cell
-                when Caracal::Core::Models::TableCellModel
-                  data_cell
-                when Hash
-                  Caracal::Core::Models::TableCellModel.new(data_cell)
-                when Proc
-                  Caracal::Core::Models::TableCellModel.new(&data_cell)
-                else
-                  Caracal::Core::Models::TableCellModel.new({ content: data_cell.to_s })
-                end
-              end
+            @table_rows = value.map do |data_row|
+              Caracal::Core::Models::TableRowModel.new(data_row: data_row)
             end
           rescue
             raise Caracal::Errors::InvalidTableDataError, 'Table data must be a two-dimensional array.'
           end
-        end        
-        
-        
+        end
+
+
         #=============== VALIDATION ==============================
-        
+
         def valid?
           cells.first.is_a?(Caracal::Core::Models::TableCellModel)
         end
-        
-        
+
+
         #-------------------------------------------------------------
         # Private Instance Methods
         #-------------------------------------------------------------
         private
-        
+
         def default_cell_width
           cell_widths     = rows.first.map { |c| c.cell_width.to_i }
           remaining_width = table_width - cell_widths.reduce(&:+).to_i
           remaining_cols  = cols.size - cell_widths.reject { |w| w == 0 }.size
           default_width   = (remaining_cols == 0) ? 0 : (remaining_width / remaining_cols)
         end
-        
+
         def option_keys
           k = []
           k << [:data, :align, :width]
@@ -198,9 +195,9 @@ module Caracal
           k << [:border_bottom, :border_left, :border_right, :border_top, :border_horizontal, :border_vertical]
           k.flatten
         end
-        
+
       end
-      
+
     end
   end
 end

--- a/lib/caracal/core/models/table_row_model.rb
+++ b/lib/caracal/core/models/table_row_model.rb
@@ -1,0 +1,135 @@
+require 'caracal/core/models/base_model'
+require 'caracal/core/models/border_model'
+require 'caracal/core/models/table_cell_model'
+
+
+module Caracal
+  module Core
+    module Models
+
+      # This class handles block options passed to tables via their data
+      # collections.
+      #
+      class TableRowModel < BaseModel
+
+        #-------------------------------------------------------------
+        # Configuration
+        #-------------------------------------------------------------
+
+        # constants
+        const_set(:HEIGHT_CALCULATION_TYPES,   [ :auto, :at_least, :exact])
+        const_set(:DEFAULT_KEEP_TOGETHER,      false)
+        const_set(:DEFAULT_HEIGHT,             250)
+        const_set(:DEFAULT_HEIGHT_CALCULATION, :auto)
+
+        # accessors
+        attr_reader :row_keep_together
+        attr_reader :row_height
+
+
+        # initialization
+        def initialize(options={}, &block)
+          @row_keep_together      = DEFAULT_KEEP_TOGETHER
+          @row_height             = DEFAULT_HEIGHT
+          @row_height_calculation = DEFAULT_HEIGHT_CALCULATION
+
+          super options, &block
+        end
+
+
+        #-------------------------------------------------------------
+        # Public Methods
+        #-------------------------------------------------------------
+
+        #=============== DATA ACCESSORS =======================
+
+        def cells
+          @cells ||= []
+        end
+
+
+        #=============== STYLES ===============================
+
+        # This method allows styles to be applied to this row
+        # from the table level.  It attempts to add the style
+        # to this row
+        #
+        # In all cases, invalid options will simply be ignored.
+        #
+        def apply_styles(opts={})
+          # make dup of options so we don't
+          # harm args sent to sibling rows
+          options = opts.dup
+
+          # data_row is not a style
+          allowed_keys = option_keys.drop(1)
+
+          # first, try apply to self
+          options.each do |(k,v)|
+            send(k, v)  if allowed_keys.include?(k)
+          end
+        end
+
+        #=============== GETTERS ==============================
+
+        def row_height_calculation
+          Caracal::Utilities.camel_case_lower(@row_height_calculation)
+        end
+
+        #=============== SETTERS ==============================
+
+        # integers
+        [:height].each do |m|
+          define_method "#{ m }" do |value|
+            instance_variable_set("@row_#{ m }", value.to_i)
+          end
+        end
+
+        # booleans
+        [:keep_together].each do |m|
+          define_method "#{ m }" do |value|
+            instance_variable_set( "@row_#{ m }", !!value)
+          end
+        end
+
+        def height_calculation(value)
+          @row_height_calculation = value if HEIGHT_CALCULATION_TYPES.include?(value)
+        end
+
+        # .data_row
+        def data_row(value)
+          @cells = value.map do |data_cell|
+            case data_cell
+            when Caracal::Core::Models::TableCellModel
+              data_cell
+            when Hash
+              Caracal::Core::Models::TableCellModel.new(data_cell)
+            when Proc
+              Caracal::Core::Models::TableCellModel.new(&data_cell)
+            else
+              Caracal::Core::Models::TableCellModel.new({ content: data_cell.to_s })
+            end
+          end
+        end
+
+        #=============== VALIDATION ===========================
+
+        def valid?
+          cells.size > 0
+        end
+
+
+        #-------------------------------------------------------------
+        # Private Instance Methods
+        #-------------------------------------------------------------
+        private
+
+        def option_keys
+          [:data_row, :keep_together, :height, :height_calculation]
+        end
+
+      end
+
+    end
+  end
+end

--- a/lib/caracal/renderers/document_renderer.rb
+++ b/lib/caracal/renderers/document_renderer.rb
@@ -349,9 +349,13 @@ module Caracal
           end
 
           rowspan_hash = {}
-          model.rows.each do |row|
+          model.table_rows.each do |row|
             xml['w'].tr do
-              row.each_with_index do |tc, tc_index|
+              xml['w'].trPr do
+                xml['w'].cantSplit if row.row_keep_together
+                xml['w'].trHeight({ "w:val" => row.row_height, "w:hRule" => row.row_height_calculation })
+              end
+              row.cells.each_with_index do |tc, tc_index|
                 xml['w'].tc do
                   xml['w'].tcPr do
                     xml['w'].shd({ 'w:fill' => tc.cell_background })

--- a/lib/caracal/utilities.rb
+++ b/lib/caracal/utilities.rb
@@ -1,16 +1,16 @@
 # We're using this strategy borrowed from ActiveSupport to
-# make command syntax a little more flexible. In a perfect 
-# world we'd just use the double splat feature of Ruby, but 
-# support for that is pretty limited at this point, so we're 
+# make command syntax a little more flexible. In a perfect
+# world we'd just use the double splat feature of Ruby, but
+# support for that is pretty limited at this point, so we're
 # going the extra mile to be cool.
 #
 module Caracal
   class Utilities
-    
+
     #-------------------------------------------------------------
     # Public Class Methods
     #-------------------------------------------------------------
-    
+
     def self.extract_options!(args)
       if args.last.is_a?(Hash)
         args.pop
@@ -18,6 +18,9 @@ module Caracal
         {}
       end
     end
-    
+
+    def self.camel_case_lower(value)
+      value.to_s.split('_').inject([]){ |buffer,e| buffer.push(buffer.empty? ? e : e.capitalize) }.join
+    end
   end
 end


### PR DESCRIPTION
Added options for setting height and cantSplit (keep_together)  for each row individually.

Tried to keep it similar to cell stilling, and to keep backward compatibility, setting those new values to defaults that should not change anything.

For backward compatibility, i created  **table_rows** that is a list of  **TableRowModel**, and changed **rows** to map **table_rows** to the old format of an matrix of cells. But, would be better find someway to make **TableRowModel** fully comparability with the old simple array row.

https://github.com/trade-informatics/caracal/issues/119 row height settings