### PR TITLE
Enable streaming file output

### DIFF
--- a/caracal.gemspec
+++ b/caracal.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'nokogiri', '~> 1.6'
-  spec.add_dependency 'rubyzip',  '~> 1.1'
+  spec.add_dependency 'zip_tricks',  '~> 4.7'
   spec.add_dependency 'tilt',     '>= 1.4'
 
   spec.add_development_dependency 'bundler',  '~> 1.3'

--- a/lib/caracal/core/models/iframe_model.rb
+++ b/lib/caracal/core/models/iframe_model.rb
@@ -1,5 +1,6 @@
 require 'caracal/core/models/base_model'
-
+require 'caracal/core/zip_reader'
+require 'tempfile'
 module Caracal
   module Core
     module Models
@@ -32,15 +33,13 @@ module Caracal
         #=============== PROCESSING =======================
 
         def preprocess!
-          ::Zip::File.open(file) do |zip|
+          Caracal::Core::ZipReader.open(file) do |zip|
             # locate relationships xml
-            entry      = zip.glob('word/_rels/document.xml.rels').first
-            content    = entry.get_input_stream.read
+            content    = zip.read_full('word/_rels/document.xml.rels')
             rel_xml    = Nokogiri::XML(content)
 
             # locate document xml
-            entry      = zip.glob('word/document.xml').first
-            content    = entry.get_input_stream.read
+            content    = zip.read_full('word/document.xml')
             doc_xml    = Nokogiri::XML(content)
 
             # master nodesets
@@ -74,7 +73,7 @@ module Caracal
               p_node  = node.children[0].children[0]
               p_id    = p_node.attributes['id'].to_s.to_i
               p_name  = p_node.attributes['name'].to_s
-              p_data  = zip.glob(r_media).first.get_input_stream.read
+              p_data  = zip.read_full(r_media)
 
               # register relationship
               array << { id: r_id, type: 'image', target: p_name, data: p_data }

--- a/lib/caracal/core/zip_reader.rb
+++ b/lib/caracal/core/zip_reader.rb
@@ -1,0 +1,32 @@
+require 'zip_tricks'
+
+module Caracal
+  module Core
+
+    # Functions as a small reader adapter for the other models that read ZIPs
+    class ZipReader
+      def self.open(file_path)
+        File.open(file_path, 'rb') do |f|
+          yield(new(f))
+        end
+      end
+
+      def initialize(seekable_io)
+        reader = ZipTricks::FileReader.new
+        entries = reader.read_zip_structure(io: seekable_io, read_local_headers: true)
+        @seekable_io = seekable_io
+        @entries_hash = entries.each_with_object({}) do |entry, h|
+          h[entry.filename] = entry
+        end
+      end
+
+      def read_full(file_name_in_archive)
+        entry = @entries_hash.fetch(file_name_in_archive)
+        reader = entry.extractor_from(@seekable_io)
+        out = StringIO.new
+        out << reader.extract(65*1024) until reader.eof?
+        out.string
+      end
+    end
+  end
+end

--- a/lib/caracal/renderers/document_renderer.rb
+++ b/lib/caracal/renderers/document_renderer.rb
@@ -107,13 +107,13 @@ module Caracal
       end
 
       def render_iframe(xml, model)
-        ::Zip::File.open(model.file) do |zip|
+        Caracal::Core::ZipReader.open(model.file) do |zip|
           a_href     = 'http://schemas.openxmlformats.org/drawingml/2006/main'
           pic_href   = 'http://schemas.openxmlformats.org/drawingml/2006/picture'
           r_href     = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships'
 
-          entry      = zip.glob('word/document.xml').first
-          content    = entry.get_input_stream.read
+
+          content    = zip.read_full('word/document.xml')
           doc_xml    = Nokogiri::XML(content)
 
           fragment = doc_xml.xpath('//w:body').first.children


### PR DESCRIPTION
This replaces Rubyzip with ZipTricks, and adds `render_to` on the Document class. `render_to` will write to any IO object without needing it to be rewindable or seekable.

This permits output to a socket or to a streaming web response, and allows memory savings when the output is large. The deflated writer in ZipTricks also regularly flushes the written bytes, making sure that not too many string buffers get accumulated.

⚠️ Note that ZipTricks uses keyword arguments, so this will effectively make Caracal require Ruby 2.1+