### PR TITLE
Patch image model

### DIFF
--- a/lib/caracal/core/models/image_model.rb
+++ b/lib/caracal/core/models/image_model.rb
@@ -72,7 +72,7 @@ module Caracal
         end
         
         def relationship_target
-          image_url || image_data
+          image_data || image_url
         end
         
         
@@ -115,7 +115,7 @@ module Caracal
         private
         
         def option_keys
-          [:url, :width, :height, :align, :top, :bottom, :left, :right]
+          [:url, :width, :height, :align, :top, :bottom, :left, :right, :data]
         end
         
         def pixels_to_emus(value, ppi)

--- a/spec/lib/caracal/core/images_spec.rb
+++ b/spec/lib/caracal/core/images_spec.rb
@@ -14,10 +14,11 @@ describe Caracal::Core::Images do
     describe '.img' do
       let!(:size) { subject.contents.size }
       
-      before { subject.img 'https://www.google.com/images/srpr/logo11w.png', width: 538, height: 190 }
+      before { subject.img 'https://www.google.com/images/srpr/logo11w.png', width: 538, height: 190, data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z/D/PwAHAwL/qGeMxAAAAABJRU5ErkJggg==" }
       
       it { expect(subject.contents.size).to eq size + 1 }
       it { expect(subject.contents.last).to be_a(Caracal::Core::Models::ImageModel) }
+      it { expect(subject.contents.last.image_data).to be_truthy}
     end
     
   end


### PR DESCRIPTION
This PR updates the image model to Include the image_data as allowed property and updates the relationship target to prefer to use the data over the configured URL. Added a test to assert that the image_data value is set as expected. The base64 string contains a pink PNG pixel.

This solves #131