### PR TITLE
Page numbers header footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,16 @@ docx.p do
 end
 ```
 
+PAGE and NUMPAGES fields can be added to runs using the `field` method
+
+```ruby
+docx.p do
+  text 'Pages '
+  field :page
+  text ' to ' 
+  field :numpages
+```
+
 
 ### Links
 

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ docx.page     # starts a new page.
 
 Page numbers can be added to the footer via the `page_numbers` method.  The method accepts optional parameters for controlling the alignment, label and size of the text.
 
-*Page numbers are turned off by default.*
+*Page numbers are turned off by default, but they supercede the `.footer` when turned on.*
 
 ```ruby
 docx.page_numbers true do
@@ -315,6 +315,24 @@ end
 ```
 
 The `size` option and the `label_size` and `number_size` options are mutually exclusive.
+
+
+### Footer
+
+A footer appearing on every page can be added via the `footer` method. Its block takes a footer object that supports text and table methods.
+
+*This is superceded by `page_numbers`, but can be used instead to provide a more complext page number footer.*
+
+```ruby
+docx.footer do |footer|
+  footer.p do
+    text 'Pages ' 
+    field :page
+    text ' of '
+    field :numpages
+  end
+end
+```
 
 
 ### Fonts

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ docx.page     # starts a new page.
 
 Page numbers can be added to the footer via the `page_numbers` method.  The method accepts optional parameters for controlling the alignment, label and size of the text.
 
-*Page numbers are turned off by default, but they supercede the `.footer` when turned on.*
+*Page numbers are turned off by default.*
 
 ```ruby
 docx.page_numbers true do
@@ -316,17 +316,16 @@ end
 
 The `size` option and the `label_size` and `number_size` options are mutually exclusive.
 
-
 ### Footer
 
 A footer appearing on every page can be added via the `footer` method. Its block takes a footer object that supports text and table methods.
 
-*This is superceded by `page_numbers`, but can be used instead to provide a more complext page number footer.*
+_This is superceded by `page_numbers`, but can be used instead to provide a more complex page number footer._
 
 ```ruby
 docx.footer do |footer|
   footer.p do
-    text 'Pages ' 
+    text 'Pages '
     field :page
     text ' of '
     field :numpages
@@ -334,6 +333,15 @@ docx.footer do |footer|
 end
 ```
 
+### Header
+
+A header appearing on every page can be added via the `header` method. Its block takes a header object that supports text and table methods.
+
+```ruby
+docx.header do |header|
+  header.p 'hello there'
+end
+```
 
 ### Fonts
 
@@ -456,10 +464,9 @@ PAGE and NUMPAGES fields can be added to runs using the `field` method
 docx.p do
   text 'Pages '
   field :page
-  text ' to ' 
+  text ' to '
   field :numpages
 ```
-
 
 ### Links
 

--- a/lib/caracal.rb
+++ b/lib/caracal.rb
@@ -38,3 +38,11 @@ Caracal::Core::Models::TableCellModel.class_eval do
   include Caracal::Core::Tables
   include Caracal::Core::Text
 end
+
+Caracal::Core::Models::FooterModel.class_eval do
+  include Caracal::Core::Images
+  include Caracal::Core::Lists
+  include Caracal::Core::Rules
+  include Caracal::Core::Tables
+  include Caracal::Core::Text
+end

--- a/lib/caracal.rb
+++ b/lib/caracal.rb
@@ -46,3 +46,11 @@ Caracal::Core::Models::FooterModel.class_eval do
   include Caracal::Core::Tables
   include Caracal::Core::Text
 end
+
+Caracal::Core::Models::HeaderModel.class_eval do
+  include Caracal::Core::Images
+  include Caracal::Core::Lists
+  include Caracal::Core::Rules
+  include Caracal::Core::Tables
+  include Caracal::Core::Text
+end

--- a/lib/caracal/core/footer.rb
+++ b/lib/caracal/core/footer.rb
@@ -1,0 +1,34 @@
+require 'caracal/core/models/footer_model'
+require 'caracal/errors'
+
+
+module Caracal
+  module Core
+
+    # This module encapsulates all the functionality related to adding tables
+    # to the document.
+    #
+    module Footer
+      def self.included(base)
+        base.class_eval do
+
+          #-------------------------------------------------------------
+          # Public Methods
+          #-------------------------------------------------------------
+
+          def footer(*args, &block)
+            options = Caracal::Utilities.extract_options!(args)
+
+            model = Caracal::Core::Models::FooterModel.new(options, &block)
+
+            @footer_content = model
+
+            model
+          end
+
+        end
+      end
+    end
+
+  end
+end

--- a/lib/caracal/core/header.rb
+++ b/lib/caracal/core/header.rb
@@ -1,14 +1,14 @@
-require 'caracal/core/models/footer_model'
+require 'caracal/core/models/header_model'
 require 'caracal/errors'
 
 
 module Caracal
   module Core
 
-    # This module encapsulates all the functionality related to adding a
-    # footer on every page of the document.
+    # This module encapsulates all the functionality related to adding a header
+    # to every page of the document.
     #
-    module Footer
+    module Header
       def self.included(base)
         base.class_eval do
 
@@ -16,16 +16,15 @@ module Caracal
           # Public Methods
           #-------------------------------------------------------------
 
-          def footer(*args, &block)
+          def header(*args, &block)
             options = Caracal::Utilities.extract_options!(args)
 
-            model = Caracal::Core::Models::FooterModel.new(options, &block)
+            model = Caracal::Core::Models::HeaderModel.new(options, &block)
 
-            @footer_content = model
+            @header_content = model
 
             model
           end
-
         end
       end
     end

--- a/lib/caracal/core/models/field_model.rb
+++ b/lib/caracal/core/models/field_model.rb
@@ -1,0 +1,137 @@
+require 'caracal/core/models/base_model'
+
+
+module Caracal
+  module Core
+    module Models
+
+      # This class encapsulates the logic needed to store and manipulate
+      # text data.
+      #
+      class FieldModel < BaseModel
+
+        #--------------------------------------------------
+        # Configuration
+        #--------------------------------------------------
+
+        # constants
+        const_set(:TYPE_MAP, { page: 'PAGE', numpages: 'NUMPAGES' })
+
+        # accessors
+        attr_reader :field_dirty
+        attr_reader :field_type
+        attr_reader :field_style
+        attr_reader :field_font
+        attr_reader :field_color
+        attr_reader :field_size
+        attr_reader :field_bold
+        attr_reader :field_italic
+        attr_reader :field_underline
+        attr_reader :field_bgcolor
+        attr_reader :field_highlight_color
+        attr_reader :field_vertical_align
+
+        #-------------------------------------------------------------
+        # Public Class Methods
+        #-------------------------------------------------------------
+
+        def self.formatted_type(type)
+          TYPE_MAP.fetch(type.to_s.to_sym)
+        end
+
+
+        #-------------------------------------------------------------
+        # Public Instance Methods
+        #-------------------------------------------------------------
+
+        #=============== GETTERS ==============================
+
+        def formatted_type
+          self.class.formatted_type(field_type)
+        end
+
+        #========== GETTERS ===============================
+
+        # .run_attributes
+        def run_attributes
+          {
+            style:            field_style,
+            font:             field_font,
+            color:            field_color,
+            size:             field_size,
+            bold:             field_bold,
+            italic:           field_italic,
+            underline:        field_underline,
+            bgcolor:          field_bgcolor,
+            highlight_color:  field_highlight_color,
+            vertical_align:   field_vertical_align
+          }
+        end
+
+
+        #========== SETTERS ===============================
+
+        # booleans
+        [:bold, :italic, :underline].each do |m|
+          define_method "#{ m }" do |value|
+            instance_variable_set("@field_#{ m }", !!value)
+          end
+        end
+
+        # integers
+        [:size].each do |m|
+          define_method "#{ m }" do |value|
+            instance_variable_set("@field_#{ m }", value.to_i)
+          end
+        end
+
+        # strings
+        [:bgcolor, :color, :dirty, :font, :highlight_color, :style, :type,].each do |m|
+          define_method "#{ m }" do |value|
+            instance_variable_set("@field_#{ m }", value.to_s)
+          end
+        end
+
+        # symbols
+        [:vertical_align].each do |m|
+          define_method "#{ m }" do |value|
+            instance_variable_set("@field_#{ m }", value.to_s.to_sym)
+          end
+        end
+
+
+        #========== VALIDATION ============================
+
+        def valid?
+          a = [:type]
+          a.map { |m| send("field_#{ m }") }.compact.size == a.size
+        end
+
+
+        #--------------------------------------------------
+        # Private Methods
+        #--------------------------------------------------
+        private
+
+        def option_keys
+          [:type, :style, :font, :color, :size, :bold, :italic, :underline, :bgcolor, :highlight_color, :vertical_align]
+        end
+
+        def method_missing(method, *args, &block)
+          # TODO: Better field centric description
+
+          # I'm on the fence with respect to this implementation. We're ignoring
+          # :method_missing errors to allow syntax flexibility for paragraph-type
+          # models.  The issue is the syntax format of those models--the way we pass
+          # the content value as a special argument--coupled with the model's
+          # ability to accept nested instructions.
+          #
+          # By ignoring method missing errors here, we can pass the entire paragraph
+          # block in the initial, built-in call to :text.
+        end
+
+      end
+
+    end
+  end
+end

--- a/lib/caracal/core/models/footer_model.rb
+++ b/lib/caracal/core/models/footer_model.rb
@@ -1,0 +1,42 @@
+require 'caracal/core/models/base_model'
+require 'caracal/core/models/margin_model'
+require 'caracal/core/models/paragraph_model'
+
+
+module Caracal
+  module Core
+    module Models
+
+      # This class handles block options passed to tables via their data
+      # collections.
+      #
+      class FooterModel < BaseModel
+
+        #-------------------------------------------------------------
+        # Configuration
+        #-------------------------------------------------------------
+
+        # initialization
+        def initialize(options={}, &block)
+          super options, &block
+        end
+
+        #-------------------------------------------------------------
+        # Public Methods
+        #-------------------------------------------------------------
+
+        #=============== DATA ACCESSORS =======================
+
+        def contents
+          @contents ||= []
+        end
+
+        #=============== VALIDATION ===========================
+
+        def valid?
+          contents.size > 0
+        end
+      end
+    end
+  end
+end

--- a/lib/caracal/core/models/header_model.rb
+++ b/lib/caracal/core/models/header_model.rb
@@ -1,0 +1,42 @@
+require 'caracal/core/models/base_model'
+require 'caracal/core/models/margin_model'
+require 'caracal/core/models/paragraph_model'
+
+
+module Caracal
+  module Core
+    module Models
+
+      # This class handles block options passed to tables via their data
+      # collections.
+      #
+      class HeaderModel < BaseModel
+
+        #-------------------------------------------------------------
+        # Configuration
+        #-------------------------------------------------------------
+
+        # initialization
+        def initialize(options={}, &block)
+          super options, &block
+        end
+
+        #-------------------------------------------------------------
+        # Public Methods
+        #-------------------------------------------------------------
+
+        #=============== DATA ACCESSORS =======================
+
+        def contents
+          @contents ||= []
+        end
+
+        #=============== VALIDATION ===========================
+
+        def valid?
+          contents.size > 0
+        end
+      end
+    end
+  end
+end

--- a/lib/caracal/core/models/paragraph_model.rb
+++ b/lib/caracal/core/models/paragraph_model.rb
@@ -2,6 +2,7 @@ require 'caracal/core/models/base_model'
 require 'caracal/core/models/bookmark_model'
 require 'caracal/core/models/link_model'
 require 'caracal/core/models/text_model'
+require 'caracal/core/models/field_model'
 require 'caracal/errors'
 
 
@@ -123,6 +124,20 @@ module Caracal
         def br
           model = Caracal::Core::Models::LineBreakModel.new()
           runs << model
+          model
+        end
+
+        # .page_num
+        def field(*args, &block)
+          options = Caracal::Utilities.extract_options!(args)
+          options = options.merge({ type: args[0] })
+
+          model = Caracal::Core::Models::FieldModel.new(options, &block)
+          if model.valid?
+            runs << model
+          else
+            raise Caracal::Errors::InvalidModelError, ':page_num method must receive a string for the display text.'
+          end
           model
         end
 

--- a/lib/caracal/core/models/relationship_model.rb
+++ b/lib/caracal/core/models/relationship_model.rb
@@ -18,6 +18,7 @@ module Caracal
         TYPE_MAP = {
           font:       'http://schemas.openxmlformats.org/officeDocument/2006/relationships/fontTable', 
           footer:     'http://schemas.openxmlformats.org/officeDocument/2006/relationships/footer',
+          header:     'http://schemas.openxmlformats.org/officeDocument/2006/relationships/header',
           image:      'http://schemas.openxmlformats.org/officeDocument/2006/relationships/image',
           link:       'http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink',
           numbering:  'http://schemas.openxmlformats.org/officeDocument/2006/relationships/numbering',

--- a/lib/caracal/core/relationships.rb
+++ b/lib/caracal/core/relationships.rb
@@ -4,42 +4,43 @@ require 'caracal/errors'
 
 module Caracal
   module Core
-
-    # This module encapsulates all the functionality related to registering and
+    
+    # This module encapsulates all the functionality related to registering and 
     # retrieving relationships.
     #
     module Relationships
       def self.included(base)
         base.class_eval do
-
+          
           #-------------------------------------------------------------
           # Configuration
           #-------------------------------------------------------------
-
+          
           attr_reader :relationship_counter
-
-
+          
+          
           #-------------------------------------------------------------
           # Class Methods
           #-------------------------------------------------------------
-
+          
           def self.default_relationships
             [
               { target: 'fontTable.xml',  type: :font      },
               { target: 'footer1.xml',    type: :footer    },
+              { target: 'header1.xml',    type: :header    },
               { target: 'numbering.xml',  type: :numbering },
               { target: 'settings.xml',   type: :setting   },
               { target: 'styles.xml',     type: :style     }
-            ]
+            ]           
           end
-
-
+          
+          
           #-------------------------------------------------------------
           # Public Methods
           #-------------------------------------------------------------
-
+          
           #============== ATTRIBUTES ==========================
-
+          
           def relationship(options={}, &block)
             id = relationship_counter.to_i + 1
             options.merge!({ id: id })
@@ -53,21 +54,21 @@ module Caracal
             end
             rel
           end
-
-
+          
+          
           #============== GETTERS =============================
-
+          
           def relationships
             @relationships ||= []
           end
-
+                    
           def find_relationship(target)
             relationships.find { |r| r.matches?(target) }
           end
-
-
+          
+          
           #============== REGISTRATION ========================
-
+          
           def register_relationship(model)
             unless r = find_relationship(model.relationship_target)
               relationships << model
@@ -75,16 +76,16 @@ module Caracal
             end
             r
           end
-
+          
           def unregister_relationship(target)
             if r = find_relationship(target)
               relationships.delete(r)
             end
           end
-
+          
         end
       end
     end
-
+    
   end
 end

--- a/lib/caracal/core/relationships.rb
+++ b/lib/caracal/core/relationships.rb
@@ -4,25 +4,25 @@ require 'caracal/errors'
 
 module Caracal
   module Core
-    
-    # This module encapsulates all the functionality related to registering and 
+
+    # This module encapsulates all the functionality related to registering and
     # retrieving relationships.
     #
     module Relationships
       def self.included(base)
         base.class_eval do
-          
+
           #-------------------------------------------------------------
           # Configuration
           #-------------------------------------------------------------
-          
+
           attr_reader :relationship_counter
-          
-          
+
+
           #-------------------------------------------------------------
           # Class Methods
           #-------------------------------------------------------------
-          
+
           def self.default_relationships
             [
               { target: 'fontTable.xml',  type: :font      },
@@ -30,16 +30,16 @@ module Caracal
               { target: 'numbering.xml',  type: :numbering },
               { target: 'settings.xml',   type: :setting   },
               { target: 'styles.xml',     type: :style     }
-            ]           
+            ]
           end
-          
-          
+
+
           #-------------------------------------------------------------
           # Public Methods
           #-------------------------------------------------------------
-          
+
           #============== ATTRIBUTES ==========================
-          
+
           def relationship(options={}, &block)
             id = relationship_counter.to_i + 1
             options.merge!({ id: id })
@@ -53,21 +53,21 @@ module Caracal
             end
             rel
           end
-          
-          
+
+
           #============== GETTERS =============================
-          
+
           def relationships
             @relationships ||= []
           end
-                    
+
           def find_relationship(target)
             relationships.find { |r| r.matches?(target) }
           end
-          
-          
+
+
           #============== REGISTRATION ========================
-          
+
           def register_relationship(model)
             unless r = find_relationship(model.relationship_target)
               relationships << model
@@ -75,16 +75,16 @@ module Caracal
             end
             r
           end
-          
+
           def unregister_relationship(target)
             if r = find_relationship(target)
               relationships.delete(r)
             end
           end
-          
+
         end
       end
     end
-    
+
   end
 end

--- a/lib/caracal/document.rb
+++ b/lib/caracal/document.rb
@@ -6,6 +6,7 @@ require 'caracal/core/custom_properties'
 require 'caracal/core/file_name'
 require 'caracal/core/fonts'
 require 'caracal/core/footer'
+require 'caracal/core/header'
 require 'caracal/core/iframes'
 require 'caracal/core/ignorables'
 require 'caracal/core/images'
@@ -28,6 +29,7 @@ require 'caracal/renderers/custom_renderer'
 require 'caracal/renderers/document_renderer'
 require 'caracal/renderers/fonts_renderer'
 require 'caracal/renderers/footer_renderer'
+require 'caracal/renderers/header_renderer'
 require 'caracal/renderers/numbering_renderer'
 require 'caracal/renderers/package_relationships_renderer'
 require 'caracal/renderers/relationships_renderer'
@@ -65,6 +67,7 @@ module Caracal
     include Caracal::Core::Text
 
     include Caracal::Core::Footer
+    include Caracal::Core::Header
 
 
     #------------------------------------------------------
@@ -153,6 +156,7 @@ module Caracal
         render_custom(zip)
         render_fonts(zip)
         render_footer(zip)
+        render_header(zip)
         render_settings(zip)
         render_styles(zip)
         render_document(zip)
@@ -225,6 +229,13 @@ module Caracal
       content = ::Caracal::Renderers::FooterRenderer.render(self)
 
       zip.put_next_entry('word/footer1.xml')
+      zip.write(content)
+    end
+
+    def render_header(zip)
+      content = ::Caracal::Renderers::HeaderRenderer.render(self)
+
+      zip.put_next_entry('word/header1.xml')
       zip.write(content)
     end
 

--- a/lib/caracal/document.rb
+++ b/lib/caracal/document.rb
@@ -5,6 +5,7 @@ require 'caracal/core/bookmarks'
 require 'caracal/core/custom_properties'
 require 'caracal/core/file_name'
 require 'caracal/core/fonts'
+require 'caracal/core/footer'
 require 'caracal/core/iframes'
 require 'caracal/core/ignorables'
 require 'caracal/core/images'
@@ -63,6 +64,8 @@ module Caracal
     include Caracal::Core::Tables
     include Caracal::Core::Text
 
+    include Caracal::Core::Footer
+
 
     #------------------------------------------------------
     # Public Class Methods
@@ -91,8 +94,6 @@ module Caracal
       #
       # File.open(docx.path, 'wb') { |f| f.write(buffer.string) }
     end
-
-
 
     #------------------------------------------------------
     # Public Instance Methods
@@ -127,6 +128,14 @@ module Caracal
     #
     def contents
       @contents ||= []
+    end
+
+    def footer_content
+      @footer_content
+    end
+
+    def header_content
+      @header_content
     end
 
 

--- a/lib/caracal/renderers/content_types_renderer.rb
+++ b/lib/caracal/renderers/content_types_renderer.rb
@@ -28,6 +28,7 @@ module Caracal
             xml.send 'Override', { 'PartName' => '/docProps/custom.xml', 'ContentType' => 'application/vnd.openxmlformats-officedocument.custom-properties+xml' }
             xml.send 'Override', { 'PartName' => '/word/document.xml',   'ContentType' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml' }
             xml.send 'Override', { 'PartName' => '/word/footer1.xml',    'ContentType' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.footer+xml' }
+            xml.send 'Override', { 'PartName' => '/word/header1.xml',    'ContentType' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml' }
             xml.send 'Override', { 'PartName' => '/word/fontTable.xml',  'ContentType' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.fontTable+xml' }
             xml.send 'Override', { 'PartName' => '/word/numbering.xml',  'ContentType' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.numbering+xml' }
             xml.send 'Override', { 'PartName' => '/word/settings.xml',   'ContentType' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.settings+xml' }

--- a/lib/caracal/renderers/document_renderer.rb
+++ b/lib/caracal/renderers/document_renderer.rb
@@ -31,10 +31,8 @@ module Caracal
               #============= PAGE SETTINGS ==============================
 
               xml['w'].sectPr do
-                if document.page_number_show
-                  if rel = document.find_relationship('footer1.xml')
-                    xml['w'].footerReference({ 'r:id' => rel.formatted_id, 'w:type' => 'default' })
-                  end
+                if rel = document.find_relationship('footer1.xml')
+                  xml['w'].footerReference({ 'r:id' => rel.formatted_id, 'w:type' => 'default' })
                 end
                 xml['w'].pgSz page_size_options
                 xml['w'].pgMar page_margin_options

--- a/lib/caracal/renderers/document_renderer.rb
+++ b/lib/caracal/renderers/document_renderer.rb
@@ -219,6 +219,20 @@ module Caracal
         end
       end
 
+      def render_field(xml, model)
+        xml['w'].fldChar({ 'w:fldCharType' => 'begin' })
+        xml['w'].r do
+          xml['w'].rPr do
+            render_run_attributes(xml, model, false)
+          end
+          xml['w'].instrText({ 'xml:space' => 'preserve' }) do
+            xml.text model.formatted_type
+          end
+        end
+        xml['w'].fldChar({ 'w:fldCharType' => 'separate' })
+        xml['w'].fldChar({ 'w:fldCharType' => 'end' })
+      end
+
       def render_list(xml, model)
         if model.list_level == 0
           document.toplevel_lists << model

--- a/lib/caracal/renderers/document_renderer.rb
+++ b/lib/caracal/renderers/document_renderer.rb
@@ -34,6 +34,9 @@ module Caracal
                 if rel = document.find_relationship('footer1.xml')
                   xml['w'].footerReference({ 'r:id' => rel.formatted_id, 'w:type' => 'default' })
                 end
+                if rel = document.find_relationship('header1.xml')
+                  xml['w'].headerReference({ 'r:id' => rel.formatted_id, 'w:type' => 'default' })
+                end
                 xml['w'].pgSz page_size_options
                 xml['w'].pgMar page_margin_options
               end

--- a/lib/caracal/renderers/footer_renderer.rb
+++ b/lib/caracal/renderers/footer_renderer.rb
@@ -5,7 +5,7 @@ require 'caracal/renderers/xml_renderer'
 
 module Caracal
   module Renderers
-    class FooterRenderer < XmlRenderer
+    class FooterRenderer < DocumentRenderer
 
       #-------------------------------------------------------------
       # Public Methods
@@ -16,42 +16,54 @@ module Caracal
       #
       def to_xml
         builder = ::Nokogiri::XML::Builder.with(declaration_xml) do |xml|
-          xml['w'].ftr root_options do
-            xml['w'].p paragraph_options do
-              xml['w'].pPr do
-                xml['w'].contextualSpacing({ 'w:val' => '0' })
-                xml['w'].jc({ 'w:val' => "#{ document.page_number_align }" })
-              end
-              unless document.page_number_label.nil?
-                xml['w'].r run_options do
-                  xml['w'].rPr do
-                    xml['w'].rStyle({ 'w:val' => 'PageNumber' })
-                    unless document.page_number_label_size.nil?
-                      xml['w'].sz({ 'w:val'  => document.page_number_label_size })
+          if document.page_number_show
+            xml['w'].ftr root_options do
+              xml['w'].p paragraph_options do
+                xml['w'].pPr do
+                  xml['w'].contextualSpacing({ 'w:val' => '0' })
+                  xml['w'].jc({ 'w:val' => "#{ document.page_number_align }" })
+                end
+                unless document.page_number_label.nil?
+                  xml['w'].r run_options do
+                    xml['w'].rPr do
+                      xml['w'].rStyle({ 'w:val' => 'PageNumber' })
+                      unless document.page_number_label_size.nil?
+                        xml['w'].sz({ 'w:val'  => document.page_number_label_size })
+                      end
+                    end
+                    xml['w'].t({ 'xml:space' => 'preserve' }) do
+                      xml.text "#{ document.page_number_label } "
                     end
                   end
-                  xml['w'].t({ 'xml:space' => 'preserve' }) do
-                    xml.text "#{ document.page_number_label } "
+                end
+                xml['w'].r run_options do
+                  xml['w'].rPr do
+                    unless document.page_number_number_size.nil?
+                      xml['w'].sz({ 'w:val'  => document.page_number_number_size })
+                      xml['w'].szCs({ 'w:val' => document.page_number_number_size })
+                    end
+                  end
+                  xml['w'].fldChar({ 'w:fldCharType' => 'begin' })
+                  xml['w'].instrText({ 'xml:space' => 'preserve' }) do
+                    xml.text 'PAGE'
+                  end
+                  xml['w'].fldChar({ 'w:fldCharType' => 'end' })
+                end
+                xml['w'].r run_options do
+                  xml['w'].rPr do
+                    xml['w'].rtl({ 'w:val' => '0' })
                   end
                 end
               end
-              xml['w'].r run_options do
-                xml['w'].rPr do
-                  unless document.page_number_number_size.nil?
-                    xml['w'].sz({ 'w:val'  => document.page_number_number_size })
-                    xml['w'].szCs({ 'w:val' => document.page_number_number_size })
-                  end
-                end
-                xml['w'].fldChar({ 'w:fldCharType' => 'begin' })
-                xml['w'].instrText({ 'xml:space' => 'preserve' }) do
-                  xml.text 'PAGE'
-                end
-                xml['w'].fldChar({ 'w:fldCharType' => 'end' })
-              end
-              xml['w'].r run_options do
-                xml['w'].rPr do
-                  xml['w'].rtl({ 'w:val' => '0' })
-                end
+            end
+          elsif document.footer_content.present? && document.footer_content.valid?
+            xml['w'].ftr root_options do
+
+              #============= CONTENTS ===================================
+
+              document.footer_content.contents.each do |model|
+                method = render_method_for_model(model)
+                send(method, xml, model)
               end
             end
           end

--- a/lib/caracal/renderers/header_renderer.rb
+++ b/lib/caracal/renderers/header_renderer.rb
@@ -5,63 +5,23 @@ require 'caracal/renderers/xml_renderer'
 
 module Caracal
   module Renderers
-    class FooterRenderer < DocumentRenderer
+    class HeaderRenderer < DocumentRenderer
 
       #-------------------------------------------------------------
       # Public Methods
       #-------------------------------------------------------------
 
-      # This method produces the xml required for the `word/footer1.xml`
+      # This method produces the xml required for the `word/header1.xml`
       # sub-document.
       #
       def to_xml
         builder = ::Nokogiri::XML::Builder.with(declaration_xml) do |xml|
-          if document.page_number_show
-            xml['w'].ftr root_options do
-              xml['w'].p paragraph_options do
-                xml['w'].pPr do
-                  xml['w'].contextualSpacing({ 'w:val' => '0' })
-                  xml['w'].jc({ 'w:val' => "#{ document.page_number_align }" })
-                end
-                unless document.page_number_label.nil?
-                  xml['w'].r run_options do
-                    xml['w'].rPr do
-                      xml['w'].rStyle({ 'w:val' => 'PageNumber' })
-                      unless document.page_number_label_size.nil?
-                        xml['w'].sz({ 'w:val'  => document.page_number_label_size })
-                      end
-                    end
-                    xml['w'].t({ 'xml:space' => 'preserve' }) do
-                      xml.text "#{ document.page_number_label } "
-                    end
-                  end
-                end
-                xml['w'].r run_options do
-                  xml['w'].rPr do
-                    unless document.page_number_number_size.nil?
-                      xml['w'].sz({ 'w:val'  => document.page_number_number_size })
-                      xml['w'].szCs({ 'w:val' => document.page_number_number_size })
-                    end
-                  end
-                  xml['w'].fldChar({ 'w:fldCharType' => 'begin' })
-                  xml['w'].instrText({ 'xml:space' => 'preserve' }) do
-                    xml.text 'PAGE'
-                  end
-                  xml['w'].fldChar({ 'w:fldCharType' => 'end' })
-                end
-                xml['w'].r run_options do
-                  xml['w'].rPr do
-                    xml['w'].rtl({ 'w:val' => '0' })
-                  end
-                end
-              end
-            end
-          elsif document.footer_content.present? && document.footer_content.valid?
-            xml['w'].ftr root_options do
+          if document.header_content.present? && document.header_content.valid?
+            xml['w'].hdr root_options do
 
               #============= CONTENTS ===================================
 
-              document.footer_content.contents.each do |model|
+              document.header_content.contents.each do |model|
                 method = render_method_for_model(model)
                 send(method, xml, model)
               end

--- a/lib/caracal/renderers/relationships_renderer.rb
+++ b/lib/caracal/renderers/relationships_renderer.rb
@@ -6,12 +6,12 @@ require 'caracal/renderers/xml_renderer'
 module Caracal
   module Renderers
     class RelationshipsRenderer < XmlRenderer
-      
+
       #-------------------------------------------------------------
       # Public Methods
       #-------------------------------------------------------------
-      
-      # This method produces the xml required for the `word/settings.xml` 
+
+      # This method produces the xml required for the `word/settings.xml`
       # sub-document.
       #
       def to_xml
@@ -24,25 +24,25 @@ module Caracal
         end
         builder.to_xml(save_options)
       end
-      
-      
+
+
       #-------------------------------------------------------------
       # Private Methods
-      #------------------------------------------------------------- 
+      #-------------------------------------------------------------
       private
-      
+
       def rel_options(rel)
         opts = { 'Target' => rel.formatted_target, 'Type' => rel.formatted_type, 'Id' => rel.formatted_id}
         opts['TargetMode'] = 'External' if rel.target_mode?
         opts
       end
-      
+
       def root_options
         {
           'xmlns' => 'http://schemas.openxmlformats.org/package/2006/relationships'
         }
       end
-   
+
     end
   end
 end

--- a/lib/caracal/renderers/relationships_renderer.rb
+++ b/lib/caracal/renderers/relationships_renderer.rb
@@ -6,12 +6,12 @@ require 'caracal/renderers/xml_renderer'
 module Caracal
   module Renderers
     class RelationshipsRenderer < XmlRenderer
-
+      
       #-------------------------------------------------------------
       # Public Methods
       #-------------------------------------------------------------
-
-      # This method produces the xml required for the `word/settings.xml`
+      
+      # This method produces the xml required for the `word/settings.xml` 
       # sub-document.
       #
       def to_xml
@@ -24,25 +24,25 @@ module Caracal
         end
         builder.to_xml(save_options)
       end
-
-
+      
+      
       #-------------------------------------------------------------
       # Private Methods
-      #-------------------------------------------------------------
+      #------------------------------------------------------------- 
       private
-
+      
       def rel_options(rel)
         opts = { 'Target' => rel.formatted_target, 'Type' => rel.formatted_type, 'Id' => rel.formatted_id}
         opts['TargetMode'] = 'External' if rel.target_mode?
         opts
       end
-
+      
       def root_options
         {
           'xmlns' => 'http://schemas.openxmlformats.org/package/2006/relationships'
         }
       end
-
+   
     end
   end
 end

--- a/spec/lib/caracal/core/footer_spec.rb
+++ b/spec/lib/caracal/core/footer_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe Caracal::Core::Text do
+  subject { Caracal::Document.new }
+
+  #-------------------------------------------------------------
+  # Configuration
+  #-------------------------------------------------------------
+
+  describe 'configuration tests' do
+
+    # accessors
+    describe 'accessors' do
+      it { expect(subject.footer_content).to be_nil }
+    end
+  end
+
+  #-------------------------------------------------------------
+  # Public Methods
+  #-------------------------------------------------------------
+
+  describe 'public method tests' do
+
+    describe '.footer' do
+      before { subject.footer }
+
+      it { expect(subject.footer_content).not_to be_nil }
+      it { expect(subject.footer_content).to be_a(Caracal::Core::Models::FooterModel) }
+    end
+  end
+end

--- a/spec/lib/caracal/core/header_spec.rb
+++ b/spec/lib/caracal/core/header_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe Caracal::Core::Text do
+  subject { Caracal::Document.new }
+
+  #-------------------------------------------------------------
+  # Configuration
+  #-------------------------------------------------------------
+
+  describe 'configuration tests' do
+
+    # accessors
+    describe 'accessors' do
+      it { expect(subject.header_content).to be_nil }
+    end
+  end
+
+  #-------------------------------------------------------------
+  # Public Methods
+  #-------------------------------------------------------------
+
+  describe 'public method tests' do
+
+    describe '.header' do
+      before { subject.header }
+
+      it { expect(subject.header_content).not_to be_nil }
+      it { expect(subject.header_content).to be_a(Caracal::Core::Models::HeaderModel) }
+    end
+  end
+end

--- a/spec/lib/caracal/core/models/footer_model_spec.rb
+++ b/spec/lib/caracal/core/models/footer_model_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe Caracal::Core::Models::FooterModel do
+  subject do
+    described_class.new
+  end
+
+  #-------------------------------------------------------------
+  # Public Methods
+  #-------------------------------------------------------------
+
+  describe 'public method tests' do
+
+    #=============== DATA ACCESSORS ====================
+
+    describe 'data tests' do
+
+      # .contents
+      describe '.contents' do
+        it { expect(subject.contents).to be_a(Array) }
+      end
+    end
+
+    #=============== VALIDATION ========================
+
+    describe '.valid?' do
+      describe 'when content provided' do
+        before { allow(subject).to receive(:contents).and_return(['a']) }
+
+        it { expect(subject.valid?).to eq true }
+      end
+
+      describe 'when content not provided' do
+        before { allow(subject).to receive(:contents).and_return([]) }
+
+        it { expect(subject.valid?).to eq false }
+      end
+    end
+  end
+end
+

--- a/spec/lib/caracal/core/models/header_model_spec.rb
+++ b/spec/lib/caracal/core/models/header_model_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe Caracal::Core::Models::HeaderModel do
+  subject do
+    described_class.new
+  end
+
+  #-------------------------------------------------------------
+  # Public Methods
+  #-------------------------------------------------------------
+
+  describe 'public method tests' do
+
+    #=============== DATA ACCESSORS ====================
+
+    describe 'data tests' do
+
+      # .contents
+      describe '.contents' do
+        it { expect(subject.contents).to be_a(Array) }
+      end
+    end
+
+    #=============== VALIDATION ========================
+
+    describe '.valid?' do
+      describe 'when content provided' do
+        before { allow(subject).to receive(:contents).and_return(['a']) }
+
+        it { expect(subject.valid?).to eq true }
+      end
+
+      describe 'when content not provided' do
+        before { allow(subject).to receive(:contents).and_return([]) }
+
+        it { expect(subject.valid?).to eq false }
+      end
+    end
+  end
+end
+

--- a/spec/lib/caracal/core/models/paragraph_model_spec.rb
+++ b/spec/lib/caracal/core/models/paragraph_model_spec.rb
@@ -137,6 +137,23 @@ describe Caracal::Core::Models::ParagraphModel do
       it { expect(subject.runs.size).to eq length + 1 }
     end
 
+    # .field
+    describe '.field' do
+      let!(:length) { subject.runs.length }
+
+      context ':page' do
+        before { subject.field :page }
+
+        it { expect(subject.runs.size).to eq length + 1 }
+      end
+
+      context ':numpages' do
+        before { subject.field :numpages }
+
+        it { expect(subject.runs.size).to eq length + 1 }
+      end
+    end
+
     # .bookmark
     describe '.bookmark_start' do
       let!(:length) { subject.runs.length }

--- a/spec/lib/caracal/core/relationships_spec.rb
+++ b/spec/lib/caracal/core/relationships_spec.rb
@@ -15,7 +15,7 @@ describe Caracal::Core::Relationships do
 
     # .default_relationships
     describe '.default_relationships' do
-      let(:expected) { [:font, :footer, :numbering, :setting, :style] }
+      let(:expected) { [:font, :footer, :header, :numbering, :setting, :style] }
       let(:actual)   { subject.class.default_relationships.map { |r| r[:type] } }
 
       it { expect(actual).to eq expected }
@@ -105,7 +105,7 @@ describe Caracal::Core::Relationships do
         it { expect(subject.relationships.size).to eq default_length }
       end
       describe 'when not registered' do
-        before do 
+        before do
           subject.register_relationship(m1)
           subject.unregister_relationship(m2.relationship_target)
         end


### PR DESCRIPTION
Hi @jdugan. Hope you are well and enjoying the holiday season!

We are working on a basic page header and footer implementation, and hoped to get your thoughts. We haven't yet planned for the more complicated scenarios with headers / footers on even / odd pages, sections, etc since it is outside the scope of our work, but thought this might be a good foundation to build upon.

The footer implementation is a bit interesting since for backward compatibility it can be superceded by `page_numbers`.

We've also added a rudimentary `field` text helper that supports PAGE and NUMPAGES, but not yet formatting or any of the other fields. 

I am having second thoughts about adding `footer_content` and `header_content` instead of adding them directly to the `contents` array, but it does simplify the rendering logic....

Any time you can spend on this would be much appreciated. 😄 