### PR TITLE
Fix ImageModel missing :data option key

### DIFF
--- a/lib/caracal/core/models/iframe_model.rb
+++ b/lib/caracal/core/models/iframe_model.rb
@@ -4,7 +4,7 @@ module Caracal
   module Core
     module Models
 
-      # This class handles block options passed to the img method.
+      # This class handles block options passed to the iframe method.
       #
       class IFrameModel < BaseModel
 

--- a/lib/caracal/core/models/image_model.rb
+++ b/lib/caracal/core/models/image_model.rb
@@ -115,7 +115,7 @@ module Caracal
         private
         
         def option_keys
-          [:url, :width, :height, :align, :top, :bottom, :left, :right]
+          [:url, :data, :width, :height, :align, :top, :bottom, :left, :right]
         end
         
         def pixels_to_emus(value, ppi)

--- a/spec/lib/caracal/core/images_spec.rb
+++ b/spec/lib/caracal/core/images_spec.rb
@@ -13,11 +13,24 @@ describe Caracal::Core::Images do
     # .img
     describe '.img' do
       let!(:size) { subject.contents.size }
-      
-      before { subject.img 'https://www.google.com/images/srpr/logo11w.png', width: 538, height: 190 }
-      
-      it { expect(subject.contents.size).to eq size + 1 }
-      it { expect(subject.contents.last).to be_a(Caracal::Core::Models::ImageModel) }
+      let!(:url) { 'https://www.google.com/images/srpr/logo11w.png' }
+
+      describe 'when no data provided' do
+        before { subject.img url, width: 538, height: 190 }
+
+        it { expect(subject.contents.size).to eq size + 1 }
+        it { expect(subject.contents.last).to be_a(Caracal::Core::Models::ImageModel) }
+      end
+
+      describe 'when data provided as binary' do
+        let!(:binary_data) { open(url).read }
+
+        before { subject.img url, data: binary_data, width: 538, height: 190 }
+
+        it { expect(subject.contents.size).to eq size + 1 }
+        it { expect(subject.contents.last).to be_a(Caracal::Core::Models::ImageModel) }
+        it { expect(subject.contents.last.image_data).to eq binary_data }
+      end
     end
     
   end


### PR DESCRIPTION
This PR is intended to fix the issue #131 and may be a duplicate of #132 by @yholkamp (I noticed that PR after the fix), but it:
1. adds a test case that fails without the fix
2. doesn't mess with `ImageModel#relationship_target`, which is only used [to retrieve the file extension](https://github.com/urvin-compliance/caracal/blob/master/lib/caracal/core/models/relationship_model.rb#L47)

It also relates to issue #27 in a way that even after this fix there's no actual possibility to create a non-corrupted image from Base64 data:
```ruby
# /lib/caracal/document.rb#L222
def render_media(zip)
  images = relationships.select { |r| r.relationship_type == :image }
  images.each do |rel|
    if rel.relationship_data.to_s.size > 0
      content = rel.relationship_data
    else
      content = open(rel.relationship_target).read
    end

    zip.put_next_entry("word/#{ rel.formatted_target }")
    zip.write(content)
  end
end
```
The `read` method that's used with the `File` object when no `:data` was supplied returns **binary data**, not `Base64`-encoded.
Similarly, if you do pass :data to the `img` method, it has to be binary, too, and you'll get nice and valid resulting image:
```ruby
doc.img image_path,
  data: File.read(image_path), # !! not Base64.encode64(File.read(image_path))
  width: 100,
  height: 100
```

With all that said, I guess that [caracal-example](https://github.com/urvin-compliance/caracal-example/blob/master/app/views/examples/show.docx.caracal#L22) has to be updated:
```ruby
# app/views/examples/show.docx.caracal#L22
data = Base64.encode64(File.read('public/plia-login.png'))
docx.img 'public/plia-login.png', data: data, width: 400, height: 124, align: :right
# => 
data = File.read('public/plia-login.png')
docx.img 'public/plia-login.png', data: data, width: 400, height: 124, align: :right
```
I don't mind taking care of it after this PR is merged.